### PR TITLE
fix: remove bad addition in previous weight attribute update

### DIFF
--- a/safe_autonomy_sims/gym/inspection/sixdof_inspection_v0.py
+++ b/safe_autonomy_sims/gym/inspection/sixdof_inspection_v0.py
@@ -364,7 +364,7 @@ class WeightedSixDofInspectionEnv(gym.Env):
         self.prev_num_inspected = (
             self.chief.inspection_points.get_num_points_inspected()
         )
-        self.prev_weight_inspected += (
+        self.prev_weight_inspected = (
             self.chief.inspection_points.get_total_weight_inspected()
         )
 

--- a/safe_autonomy_sims/gym/inspection/weighted_inspection_v0.py
+++ b/safe_autonomy_sims/gym/inspection/weighted_inspection_v0.py
@@ -303,7 +303,7 @@ class WeightedInspectionEnv(gym.Env):
         self.prev_num_inspected = (
             self.chief.inspection_points.get_num_points_inspected()
         )
-        self.prev_weight_inspected += (
+        self.prev_weight_inspected = (
             self.chief.inspection_points.get_total_weight_inspected()
         )
 

--- a/safe_autonomy_sims/pettingzoo/inspection/sixdof_multi_inspection_v0.py
+++ b/safe_autonomy_sims/pettingzoo/inspection/sixdof_multi_inspection_v0.py
@@ -323,7 +323,7 @@ class WeightedSixDofMultiInspectionEnv(pettingzoo.ParallelEnv):
         self.prev_num_inspected = (
             self.chief.inspection_points.get_num_points_inspected()
         )
-        self.prev_weight_inspected += (
+        self.prev_weight_inspected = (
             self.chief.inspection_points.get_total_weight_inspected()
         )
 

--- a/safe_autonomy_sims/pettingzoo/inspection/weighted_multi_inspection_v0.py
+++ b/safe_autonomy_sims/pettingzoo/inspection/weighted_multi_inspection_v0.py
@@ -280,7 +280,7 @@ class WeightedMultiInspectionEnv(pettingzoo.ParallelEnv):
         self.prev_num_inspected = (
             self.chief.inspection_points.get_num_points_inspected()
         )
-        self.prev_weight_inspected += (
+        self.prev_weight_inspected = (
             self.chief.inspection_points.get_total_weight_inspected()
         )
 


### PR DESCRIPTION
Remove the addition assignment in the `prev_weight_inspected` attribute update for the inspection environments