### PR TITLE
Fixed _step_entity_state() method

### DIFF
--- a/safe_autonomy_sims/simulators/saferl_simulator.py
+++ b/safe_autonomy_sims/simulators/saferl_simulator.py
@@ -392,10 +392,8 @@ class SafeRLSimulator(BaseSimulator):
         for entity_name, entity in self.sim_entities.items():
             action = entity_actions.get(entity_name, None)
 
-            if action is not None:
-                entity.add_control(action)
-
-            entity.step(step_size=step_size)
+            if entity_name in platforms_to_action or not entity_name in self.platforms:
+                entity.step(action=action, step_size=step_size)
 
     def _step_get_entity_actions(
         self,


### PR DESCRIPTION
Addressed the issue #22 to fix entity state stepping. The method now steps the entity state if it's an actionable platform or if it's a non-platform entity (such as chief, sun, etc.).